### PR TITLE
Force config files to load even when started from TWiLightMenu++

### DIFF
--- a/arm9/source/arm9main.c
+++ b/arm9/source/arm9main.c
@@ -147,6 +147,8 @@ int main(int _argc, char **_argv) {
 	if(!bootext()) {
 		//chdir("/");
 		do_rommenu(); //show a menu selecting rom files.
+	} else {
+		hideconsole();
 	}
 #else
 	do_romebd();


### PR DESCRIPTION
This fixes a long-time bug where consoles that relied on the screen-swap to render content to the touch screen would not be able to see the game until opening and closing the menu.