### PR TITLE
Separate DSi and DS build targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,10 @@ jobs:
         run: |
           make
           chmod +x make_cia
-          ./make_cia --srl="nesDS.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+          ./make_cia --srl="nesDS.dsi" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
           mkdir nesDS/
           cp nesDS.nds nesDS/
+          cp nesDS.dsi nesDS/
           cp nesDS.cia nesDS/
       - name: Publish build to GH Actions
         uses: actions/upload-artifact@v4
@@ -40,4 +41,5 @@ jobs:
         with:
           files: |
             nesDS/nesDS.nds
+            nesDS/nesDS.dsi
             nesDS/nesDS.cia

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include $(DEVKITARM)/ds_rules
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-all: checkarm7 checkarm9 $(TARGET).nds
+all: checkarm7 checkarm9 $(TARGET).nds $(TARGET).dsi
 
 #---------------------------------------------------------------------------------
 checkarm7:
@@ -40,6 +40,12 @@ checkarm9:
 #---------------------------------------------------------------------------------
 $(TARGET).nds : $(NITRO_FILES) arm7/$(TARGET).elf arm9/$(TARGET).elf
 	ndstool	-c $(TARGET).nds -7 arm7/$(TARGET).elf -9 arm9/$(TARGET).elf \
+	-b $(GAME_ICON) "$(GAME_TITLE);$(GAME_SUBTITLE1);$(GAME_SUBTITLE2)" \
+	$(_ADDFILES)
+
+#---------------------------------------------------------------------------------
+$(TARGET).dsi : $(NITRO_FILES) arm7/$(TARGET).elf arm9/$(TARGET).elf
+	ndstool	-c $(TARGET).dsi -7 arm7/$(TARGET).elf -9 arm9/$(TARGET).elf \
 	-b $(GAME_ICON) "$(GAME_TITLE);$(GAME_SUBTITLE1);$(GAME_SUBTITLE2)" \
 	-g HNES 00 "HOMEBREW" -u 00030004 \
 	$(_ADDFILES)


### PR DESCRIPTION
The fix for #12 included a change to NesDS's game code, which was set to `HNES`.

This unfortunately causes issues with most flashcard kernels as they believe that NesDS is a game. As such, they will not attempt to DLDI patch it. In the case of TT-based kernels, they will outright refuse to load NesDS. See #32 .

I have modified the makefile to have two separate build targets, one with a game code and title ID (nesDS.dsi), and one without (nesDS.nds). I have also updated the GitHub workflow to build the CIA from `nesDS.dsi` instead of `nesDS.nds`.

I have tested that the CIA build does continue to work on a 3DS. The NDS build works on flashcards and is properly detected as homebrew. I have not tested this on a DSi, but I assume it will work given that the other two builds do.