### PR TITLE
Remove DSi build in make clean step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,4 @@ clean:
 	$(MAKE) -C arm9 clean
 	$(MAKE) -C arm7 clean
 	rm -f $(TARGET).nds
+	rm -f $(TARGET).dsi


### PR DESCRIPTION
I forgot to add a step to remove the DSi build when `make clean` is run, here is the small change needed for that.